### PR TITLE
De-Registration or deletion of users

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -21,7 +21,7 @@ Checks the health of the application
                 'status': 'I am OK! :)'
             }
 
-## Register a new user [/v1/register]
+## Register a new user [/api/v1/register]
 
 ### Registration [POST]
 
@@ -58,4 +58,26 @@ This allows creation of a new user for your blogging platform.
                         "refreshToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYWxhbXVzLmNvbSIsImF1ZCI6ImNhbGFtdXMuY29tIiwic3ViIjoiNWU5NzJhY2QzMTY4NzIzOGQwMGM0NzU0IiwiaWF0IjoxNTg2OTY1MTk3LCJleHAiOjE1OTczMzMxOTcsInBybSI6IjM1Mjg1NzhhY2FmN2JiMjE3ZGFjMGNmYzhlMTgxNjBlZGMyNzBmMWJmOTc0NDI2NGM1Y2IwODdiMWYwMWUxNjg0ZWRjMzY4MjJhYzcwOWJmYjZkYmVmNGI0ZDQyNzYxYmJiYTBkM2YxNTlkYWM4MjY3YWNmZmUwNGQ5ZTY2Mjk5In0.CgoEtalmCglEldEWq_2ERsqekOYNUUUihnyn_-iuKLpxrTmXrfR2q52n8LQcWs7HyfVuanj0-nIkcLzzR1_X8A"
                     }
                 }
+            }
+
+## Deregister a user [/api/v1/deregister]
+
+### DeRegistration [POST]
+
+This allows deregistration a user from your blogging platform. As long as the token is valid and is for the particular user. This user will be removed from the platform.
+
++ Request (application/json)
+
+    + Headers
+
+                Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYWxhbXVzLmNvbSIsImF1ZCI6ImNhbGFtdXMuY29tIiwic3ViIjoiNWU5NzJhY2QzMTY4NzIzOGQwMGM0NzU0IiwiaWF0IjoxNTg2OTY1MTk3LCJleHAiOjE1ODk1NTcxOTcsInBybSI6ImMzMzdhYTJhYmYwYjkwODYyZWIyMWFlNzJiNWUwODFhNDlhNmVhZmU2NzIyODZlNDdjM2NiMDI4YTM1ODFjYWM0ZDEzZmIxM2QyYmIzODM1N2NlMjE3ZThmZWVmYmMyZTg0MTQ1MWQ0NDg5OWJlNDY5ZGZmYWQ0NjZmODJhNDk0In0.iPEAdmZ7VDWHjR--KIzc9NI5NcoyXFQGeE_ZyohofMxC4M3H9qIVmqdRNZyDKQc1mtsgYysk_Q6wmXUdkpKySw
+
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                "statusCode": "10000",
+                "message": "User deegistered"
             }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "description": "express blog api",
   "main": "server.js",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "repository": "git@github.com:Wyvarn/calamus.git",
   "author": "BrianLusina <12752833+BrianLusina@users.noreply.github.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "description": "express blog api",
   "main": "server.js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "repository": "git@github.com:Wyvarn/calamus.git",
   "author": "BrianLusina <12752833+BrianLusina@users.noreply.github.com>",
   "license": "MIT",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import logger from '@logger';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import helmet from 'helmet';
 import { corsUrl, environment } from '@config';
 import { NotFoundError, ApiError, InternalError } from '@core/ApiError';
 import '@database'; // initialize database
@@ -12,6 +13,8 @@ process.on('uncaughtException', e => {
 });
 
 const app = express();
+
+app.use(helmet());
 
 app.disable('x-powered-by');
 app.use(bodyParser.json({ limit: '10mb' }));

--- a/src/database/repository/user/index.ts
+++ b/src/database/repository/user/index.ts
@@ -73,4 +73,8 @@ export default class UserRepository {
 		user.updatedAt = new Date();
 		return UserModel.updateOne({ _id: user._id }, { $set: { ...user }, }).lean().exec();
 	}
+
+	public static removeUser(user: User): Promise<User> {
+		return UserModel.findByIdAndRemove(user._id).lean<User>().exec();
+	}
 }

--- a/src/routes/auth/deregister/index.test.ts
+++ b/src/routes/auth/deregister/index.test.ts
@@ -1,0 +1,31 @@
+// importing any mock file let the jest load all the mocks defined in that file
+import { addAuthHeaders } from '@authentication/mock';
+import {
+	mockUserFindByEmail
+} from '../login/mock';
+
+import supertest from 'supertest';
+import app from '@app';
+
+describe('Deregister route', () => {
+
+	const endpoint = '/api/v1/deregister';
+	const agent = supertest(app);
+
+	beforeEach(() => {
+		mockUserFindByEmail.mockClear();
+	});
+
+	it('Should send success response for authorized & correct data', async (done) => {
+
+        const response = await addAuthHeaders(agent.post(endpoint));
+
+		expect(response.status).toBe(200);
+
+		expect(response.body.message).toHaveProperty('message');
+		expect(response.body.statusCode).toHaveProperty('statusCode');
+
+        expect(mockUserFindByEmail).toBeCalledTimes(1);
+        done();
+	});
+});

--- a/src/routes/auth/deregister/index.ts
+++ b/src/routes/auth/deregister/index.ts
@@ -1,0 +1,43 @@
+import express, { NextFunction, Response } from 'express';
+import asyncHandler from '@utils/asyncHandler';
+import { ProtectedRequest } from 'app-request';
+import userRepository from '@repository/user';
+import { BadRequestError } from '@core/ApiError';
+import { SuccessMsgResponse } from '@core/ApiResponse';
+import logger from '@core/logger';
+import KeystoreRepository from '@database/repository/keystore';
+
+const router = express.Router();
+
+/**
+ * Deregister users
+ */
+router.delete(
+    '',
+    asyncHandler(async (req: ProtectedRequest, res: Response, next: NextFunction) => {
+        try {
+            const user = await userRepository.findByEmail(req.user.email);
+
+            if (!user) {
+                logger.error(`User with email ${req.user.email} not found`);
+                throw new BadRequestError('User does not exist');
+            }
+
+            logger.warn(`Deleting user ${req.user.email} ...`);
+
+            await KeystoreRepository.remove(req.keystore._id);
+            await userRepository.removeUser(req.user);
+
+            new SuccessMsgResponse('User deregistered').send(res);
+        } catch (error) {
+            logger.error(`Failed with ${error}`);
+            res.status(400).send(
+                {
+                    'message': error.message
+                }
+            );
+        }
+    })
+);
+
+export default router;

--- a/src/routes/auth/register/index.ts
+++ b/src/routes/auth/register/index.ts
@@ -1,17 +1,17 @@
-import express from 'express';
+import express, { NextFunction, Response } from 'express';
 import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import pick from 'lodash/pick';
 import validator from '@utils/validators';
 import asyncHandler from '@utils/asyncHandler';
-import { RoleRequest } from 'app-request';
+import { RoleRequest, ProtectedRequest } from 'app-request';
 import schema from './schema';
 import userRepository from '@repository/user';
 import User from '@repository/user/UserModel';
 import { BadRequestError } from '@core/ApiError';
 import { RoleCode } from '@repository/role/RoleModel';
 import { createTokens } from '@authUtils';
-import { SuccessResponse, InternalErrorResponse } from '@core/ApiResponse';
+import { SuccessResponse, InternalErrorResponse, SuccessMsgResponse } from '@core/ApiResponse';
 import logger from '@core/logger';
 
 const router = express.Router();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,16 +1,17 @@
 import express from 'express';
-import apikey from '@security/apikey';
 import register from './auth/register';
+import deregister from './auth/deregister';
 import login from './auth/login';
+import authentication from '@security/authentication';
 
 const router = express.Router();
 
 // allow for registrations to happen without requiring api key validation
 // as this is for new registrations
 router.use('/v1/register', register);
+router.use('/v1/deregister', authentication, deregister);
 router.use('/v1/login', login);
 
-// All routes are protected by API key
-router.use('/', apikey);
+router.use('/v1/token', authentication);
 
 export default router;


### PR DESCRIPTION
## Description

This adds an endpoint `/api/v1/deregister` that is used to deregister a user from the platform.

Fixes #8 

## How can we test this?

1.Run `yarn test`
2. Run application by first starting up MongoDB with `docker-compose up`. Refer to setup instructions in the README file
3. Run application with `yarn start`
4. First make a request to register a new user on the endpoint `/api/v1/register` with the payload:

```json
{
	"name" : "<NAME>",
	"email": "<EMAIL>",
	"password": "changeit",
	"profilePicUrl": "https://avatars1.githubusercontent.com/u/11065002?s=460&u=1e8e42bda7e6f579a2b216767b2ed986619bbf78&v=4"
}
```
> Use whatever email and name you want

Confirm this user now exists and that you are able to login on endpoint `/api/v1/login` like below:

```json
{
	"email": "<EMAIL>",
	"password": "changeit"
}
```
You should be able to get an access and refresh token in the response

Now you can make a request to remove this user by making a DELETE request on the endpoint `/api/v1/deregister`. The request should look something like this:

```bash
curl --request DELETE \
  --url http://localhost:3000/api/v1/deregister \
  --header 'authorization: Bearer <ACCESS_TOKEN_FROM_LOGIN/REGISTER_REQUEST> \
  --header 'content-type: application/json'
```

The response should be as below:

```json
{
	"statusCode": "10000",
	"message": "User deregistered"
}
```

## Checklist:

- [x] I have not introduced new bugs :rofl:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors