### PR TITLE
Allow a Writer to submit a blog

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -347,10 +347,58 @@ Allows users with writer roles to update *THEIR* already created blog post. This
                 }
             }
 
+## Writer submit a blog [/api/v1/writer/blog/submit/{ID}]
+
+### Updates an existing blog [PATCH]
+
+Allows users with writer roles to submit *THEIR* already created blog post.
+
+
++ Request (application/json)
+
+    + Headers
+        
+            Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYWxhbXVzLmNvbSIsImF1ZCI6ImNhbGFtdXMuY29tIiwic3ViIjoiNWU5NzJhY2QzMTY4NzIzOGQwMGM0NzU0IiwiaWF0IjoxNTg2OTY1MTk3LCJleHAiOjE1ODk1NTcxOTcsInBybSI6ImMzMzdhYTJhYmYwYjkwODYyZWIyMWFlNzJiNWUwODFhNDlhNmVhZmU2NzIyODZlNDdjM2NiMDI4YTM1ODFjYWM0ZDEzZmIxM2QyYmIzODM1N2NlMjE3ZThmZWVmYmMyZTg0MTQ1MWQ0NDg5OWJlNDY5ZGZmYWQ0NjZmODJhNDk0In0.iPEAdmZ7VDWHjR--KIzc9NI5NcoyXFQGeE_ZyohofMxC4M3H9qIVmqdRNZyDKQc1mtsgYysk_Q6wmXUdkpKySw
+
+    + Parameters
+        
+        + ID (string) - id of the blog to update
+
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                "statusCode": "10000",
+                "message": "Blog submitted successfully",
+                "data": {
+                    "tags": [
+                        "NODEJS",
+                        "BACKEND"
+                    ],
+                    "likes": 0,
+                    "isSubmitted": true,
+                    "isDraft": false,
+                    "isPublished": false,
+                    "status": true,
+                    "_id": "5ea726929ae1e474030bd9cb",
+                    "title": "How NodeJS works.",
+                    "description": "Node.js is a popular framework for building backend systems (network applications) which can scale very well. Node.js is a Javascript runtime i.e. it runs the javascript codes.",
+                    "draftText": "<p>This will depend on how you render the blog. It can be html text or plain text.</p>",
+                    "author": "5ea71cfe8bdc2c55032755d2",
+                    "slug": "introduction-to-node-js-and-how-node-js-works",
+                    "imgUrl": "https://s3.ap-south-1.amazonaws.com/afteracademy-server-uploads/introduction-to-node-js-how-node-js-works-cover.jpg",
+                    "createdBy": "5ea71cfe8bdc2c55032755d2",
+                    "updatedBy": "5ea71cfe8bdc2c55032755d2",
+                    "createdAt": "2020-04-27T18:38:10.295Z",
+                    "updatedAt": "2020-04-27T18:38:10.295Z"
+                }
+            }
 
 # Data Structures
 
-## BlogResponse (object)
+## Blog (object)
 
 + tags (array) - tags this blog can be categorized into. Array of strings
 + likes (number) - Number of likes this blog has received

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "description": "express blog api",
   "main": "server.js",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "repository": "git@github.com:Wyvarn/calamus.git",
   "author": "BrianLusina <12752833+BrianLusina@users.noreply.github.com>",
   "license": "MIT",

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -60,8 +60,9 @@ export default (schema: Joi.ObjectSchema, source: ValidationSource = ValidationS
     const message = details.map((i) => i.message.replace(/['"]+/g, '')).join(',');
     logger.error(`ValidationError: ${message}`);
 
-    next(new BadRequestError(message));
+    throw new BadRequestError(message);
   } catch (error) {
+    logger.error(`ValidationError: ${error}`);
     next(error);
   }
 };


### PR DESCRIPTION
## Description

Allows an authenticated, authorized  user with Writer role to submit their blog. Which updates their
blog draft status from false to true and updates the isSubmitted flag

Fixes #30

## How can we test this?

1. Run application with `docker-compose up` & `yarn start`
2. Make a POST request to create a blog on endpoint `/api/v1/writer/blog`
3. Make a PATCH request to submit the blog post on endpoint `/api/v1/writer/blog/submit/{ID}` where the {ID} is the ID of the created blog post from the previous request's response.
4. You should get back a response where the blog's flag has its `isDraft` set to false & `isSubmitted` flag set to true.

## Checklist:

- [x] I have not introduced new bugs :rofl:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors